### PR TITLE
Animation start when visible

### DIFF
--- a/SSChart/Sources/SSChart/Bar/BarChart.swift
+++ b/SSChart/Sources/SSChart/Bar/BarChart.swift
@@ -95,8 +95,7 @@ public class BarChart: UIView {
 
 // MARK: - public
 extension BarChart {
-    /// pause bar animation
-    /// - Important: this should be called after setting items
+    /// pause bar animation. **This should be called after setting items**
     public func pauseAnimation() {
         for bar in bars {
             pauseBarAnimation(bar: bar)

--- a/SSChart/Sources/SSChart/Common/Chart.swift
+++ b/SSChart/Sources/SSChart/Common/Chart.swift
@@ -8,8 +8,23 @@
 import Foundation
 import UIKit
 
-struct ChartItemValuePercentage {
-    let start: CGFloat
-    let end: CGFloat
+protocol Chart {
+    /// pause animation. This should be called after setting items for chart.
+    func pauseAnimation()
+    func resumeAnimation()
 }
 
+extension Chart {
+    func pauseAnimation(layer: CALayer) {
+        let pausedTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+        layer.speed = 0
+        layer.timeOffset = pausedTime
+    }
+    
+    func resumeAnimation(layer: CALayer, delay: Double) {
+        let pausedTime = layer.convertTime(CACurrentMediaTime(), from: nil)
+        layer.speed = 1
+        layer.timeOffset = 0
+        layer.beginTime = CACurrentMediaTime() - pausedTime + delay
+    }
+}

--- a/SSChart/Sources/SSChart/Common/ChartItemValuePercentage.swift
+++ b/SSChart/Sources/SSChart/Common/ChartItemValuePercentage.swift
@@ -1,0 +1,14 @@
+//
+//  ChartItemValuePercentage.swift
+//  
+//
+//  Created by YJ on 2022/08/24.
+//
+
+import Foundation
+import UIKit
+
+struct ChartItemValuePercentage {
+    let start: CGFloat
+    let end: CGFloat
+}

--- a/SSChart/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/SSChart/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-public class DoughnutChart: UIView {
+public class DoughnutChart: UIView, Chart {
     
     // MARK: public
     // 유효하지 않은 값 / 새로 데이터 안 들어올 때 기본 회색 차트 노출하게 해야 함
@@ -69,22 +69,19 @@ extension DoughnutChart {
             return
         }
         
-        let pausedTime = mask.convertTime(CACurrentMediaTime(), from: nil)
-        mask.speed = 0
-        mask.timeOffset = pausedTime
+        pauseAnimation(layer: mask)
     }
     
-    public func doAnimation() {
+    public func resumeAnimation() {
         // ???: is it right to use async, put whole block in async?
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, let mask = self.doughnutLayer.mask else { return }
+            guard let self = self,
+                  let mask = self.doughnutLayer.mask,
+                  !self.didAnimation else { return }
             
             if self.didAnimation { return }
 
-            let pausedTime = mask.timeOffset
-            mask.speed = 1
-            mask.timeOffset = 0
-            mask.beginTime = CACurrentMediaTime() - pausedTime
+            self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
         }

--- a/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
@@ -35,14 +35,10 @@ public class GaugeChart: UIView {
     private let innerCircleRadius: CGFloat
     private let gaugeCenterRadius: CGFloat
     
+    private var didAnimation = false
+    
     /// percenatge of prefix sum
     private var percentages: [ChartItemValuePercentage] = []
-    
-    // MARK: - init
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        reload()
-    }
     
     // MARK: - init
     /// - Parameters:
@@ -66,6 +62,35 @@ public class GaugeChart: UIView {
     }
 }
 
+// MARK: - public
+extension GaugeChart {
+    public func pauseAnimation() {
+        guard let mask = gaugeLayer.mask else {
+            return
+        }
+        
+        let pausedTime = mask.convertTime(CACurrentMediaTime(), from: nil)
+        mask.speed = 0
+        mask.timeOffset = pausedTime
+    }
+    
+    public func doAnimation() {
+        // ???: is it right to use async, put whole block in async?
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let mask = self.gaugeLayer.mask else { return }
+            
+            if self.didAnimation { return }
+
+            let pausedTime = mask.timeOffset
+            mask.speed = 1
+            mask.timeOffset = 0
+            mask.beginTime = CACurrentMediaTime() - pausedTime
+            
+            self.didAnimation = true
+        }
+    }
+}
+
 // MARK: - private
 extension GaugeChart {
     private func reload() {
@@ -83,6 +108,8 @@ extension GaugeChart {
         
         gaugeLayer = CAShapeLayer(layer: layer)
         contentView.layer.addSublayer(gaugeLayer)
+        
+        didAnimation = false
     }
 }
 

--- a/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
@@ -10,7 +10,7 @@ import UIKit
 
 // FIXME: almost same as DoughnutChart. Consider adding protocol.
 
-public class GaugeChart: UIView {
+public class GaugeChart: UIView, Chart {
 
     // MARK: public
     // 유효하지 않은 값 / 새로 데이터 안 들어올 때 기본 회색 차트 노출하게 해야 함
@@ -69,22 +69,19 @@ extension GaugeChart {
             return
         }
         
-        let pausedTime = mask.convertTime(CACurrentMediaTime(), from: nil)
-        mask.speed = 0
-        mask.timeOffset = pausedTime
+        pauseAnimation(layer: mask)
     }
     
-    public func doAnimation() {
+    public func resumeAnimation() {
         // ???: is it right to use async, put whole block in async?
         DispatchQueue.main.async { [weak self] in
-            guard let self = self, let mask = self.gaugeLayer.mask else { return }
+            guard let self = self,
+                  let mask = self.gaugeLayer.mask,
+                  !self.didAnimation else { return }
             
             if self.didAnimation { return }
 
-            let pausedTime = mask.timeOffset
-            mask.speed = 1
-            mask.timeOffset = 0
-            mask.beginTime = CACurrentMediaTime() - pausedTime
+            self.resumeAnimation(layer: mask, delay: 0)
             
             self.didAnimation = true
         }


### PR DESCRIPTION
close #7 

### Description

Start chart animation when it becomes visible.

* Add `didAnimation` flag to check whether animation is executed.
* Add public methods `pauseAnimation()` and `doAnimation()` for pausing and resuming animation


### How to use

1. Set items of chart.
  ```swift
  private func setChartData() {
      barChart.items = createBarChartItem()
      gaugeChart.items = createGaugeChartItem()
      doughnutChart.items = createDoughnutChartItem()
  }
  ```
2. Pause animation.
```swift
private func pauseChartAnimation() {
    barChart.pauseAnimation()
    doughnutChart.pauseAnimation()
    gaugeChart.pauseAnimation()
}
```
3. Call animation resume method when necessary.
```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
    if scrollView.bounds.intersects(barChart.frame) {
        barChart.doAnimation()
    }
    
    if scrollView.bounds.intersects(doughnutChart.frame) {
        doughnutChart.doAnimation()
    }
    
    if scrollView.bounds.intersects(gaugeChart.frame) {
        gaugeChart.doAnimation()
    }
}
```

### Note

To start animation of chart which is in scrollView, we call `scrollView.bounds.intersects(barChart.frame)` to check whether chart is visible. But this is `true` before screen is visible, so we need to set origin of chart frame to some value like  `CGPoint(x: -5000, y: -5000)` to ensure chart frame is out of scrollView at the first time.

```swift
private let chartFrame = CGRect(x: -5000, y: -5000, width: UIScreen.main.bounds.width-100, height: 200)
```

### Example


![Simulator Screen Recording - iPhone 12 Pro - 2022-08-24 at 08 28 02](https://user-images.githubusercontent.com/41438361/186283537-4ae465bc-0502-4afb-b903-4e7a70c8d647.gif)

