### PR TITLE
Support drawing bar chart average line

### DIFF
--- a/SSChart/Sources/SSChart/Bar/BarChart.swift
+++ b/SSChart/Sources/SSChart/Bar/BarChart.swift
@@ -45,7 +45,6 @@ public class BarChart: UIView, Chart {
     private let averageLineColor: UIColor
     
     // MARK: calculated
-//    private var averageLine
     private var showGroupLabel              = false
     private var showItemLabel               = false
     private var showDescriptionLabel        = false

--- a/SSChart/Sources/SSChart/Doughnut/DoughnutChart.swift
+++ b/SSChart/Sources/SSChart/Doughnut/DoughnutChart.swift
@@ -22,13 +22,13 @@ public class DoughnutChart: UIView, Chart {
         }
     }
     
+    private var contentView = UIView()
+    private var doughnutLayer = CAShapeLayer()
+    
     // MARK: - user custom
     private let animationDuration: Double
     
     // MARK: - calculated
-    private var contentView = UIView()
-    private var doughnutLayer = CAShapeLayer()
-    
     private let outerCircleRadius: CGFloat
     private let innerCircleRadius: CGFloat
     private let doughnutCenterRadius: CGFloat

--- a/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
+++ b/SSChart/Sources/SSChart/Gauge/GaugeChart.swift
@@ -23,14 +23,14 @@ public class GaugeChart: UIView, Chart {
         }
     }
     
+    private var contentView = UIView()
+    private var gaugeLayer = CAShapeLayer()
+    
     // MARK: - user custom
     private let animationDuration: Double
     private let gaugeWidth: CGFloat
     
     // MARK: - calculated
-    private var contentView = UIView()
-    private var gaugeLayer = CAShapeLayer()
-    
     private let outerCircleRadius: CGFloat
     private let innerCircleRadius: CGFloat
     private let gaugeCenterRadius: CGFloat


### PR DESCRIPTION
close #11 

### Description

Now bar chart supports drawing average line.

* Create average line layer
* Add fade-in animation to average line layer. Animation starts right after all bar animations are finished.

### Example

![image](https://user-images.githubusercontent.com/41438361/186318707-2ee83f49-05b2-4dc7-99cd-bce6c8daa8a5.png)


![Simulator Screen Recording - iPhone 12 Pro - 2022-08-24 at 12 24 10](https://user-images.githubusercontent.com/41438361/186318819-7f230c48-5a63-45f1-b6ef-2fd015f31773.gif)
![Simulator Screen Recording - iPhone 12 Pro - 2022-08-24 at 12 25 02](https://user-images.githubusercontent.com/41438361/186319162-00a36fc2-e5cc-4573-9764-fe28de925847.gif)
